### PR TITLE
refactor(runtime): remove holder interfaces

### DIFF
--- a/component/container.go
+++ b/component/container.go
@@ -65,12 +65,6 @@ type HierarchicalContainer interface {
 	SetParentContainer(container Container)
 }
 
-// ContainerHolder is an interface that provides access to a Container.
-type ContainerHolder interface {
-	// Container returns the associated Container.
-	Container() Container
-}
-
 // StandardContainer is the default implementation of the Container interface.
 // It manages component definitions, singleton instances, custom scopes,
 // and lifecycle processing.
@@ -805,8 +799,13 @@ func (d *StandardContainer) resolveArguments(ctx context.Context, args []Arg) ([
 
 		if arg.Name() != "" {
 			instance, err = d.Resolve(ctx, arg.Name())
+
 		} else {
-			instance, err = d.ResolveType(ctx, arg.Type())
+			if dep, ok := d.resolveDependency(arg.Type()); ok {
+				instance = dep
+			} else {
+				instance, err = d.ResolveType(ctx, arg.Type())
+			}
 		}
 
 		if err != nil {
@@ -939,4 +938,21 @@ func (d *StandardContainer) applyAfterInitProcessors(ctx context.Context, instan
 	}
 
 	return instance, nil
+}
+
+func (d *StandardContainer) resolveDependency(typ reflect.Type) (any, bool) {
+
+	d.muResolvableInstances.RLock()
+	defer d.muResolvableInstances.RUnlock()
+	instance, ok := d.resolvableDependencies[typ]
+	if ok {
+		return instance, true
+	}
+	for depType, instance := range d.resolvableDependencies {
+		if convertibleTo(depType, typ) || convertibleTo(reflect.TypeOf(instance), typ) {
+			return instance, true
+		}
+	}
+	return nil, false
+
 }

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"codnect.io/procyon/component"
+	"codnect.io/procyon/io"
 )
 
 // Context represents the central runtime context of the application.
@@ -27,11 +28,14 @@ type Context interface {
 	// Lifecycle interface provides start/stop lifecycle methods for the application context.
 	Lifecycle
 
-	// EnvironmentHolder is an interface that provides access to an Environment.
-	EnvironmentHolder
+	// Environment returns the runtime environment associated with this context.
+	Environment() Environment
 
-	// ContainerHolder is an interface that provides access to a Container.
-	component.ContainerHolder
+	// Container returns the component container associated with this context.
+	Container() component.Container
+
+	// ResourceResolver returns the resource resolver associated with this context.
+	ResourceResolver() io.ResourceResolver
 
 	// Refresh reloads the application context contents (environment, container)
 	Refresh(ctx context.Context) error

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -47,12 +47,6 @@ type Environment interface {
 	PropertyResolver() config.PropertyResolver
 }
 
-// EnvironmentHolder is an interface that provides access to an Environment.
-type EnvironmentHolder interface {
-	// Environment returns the associated Environment.
-	Environment() Environment
-}
-
 // EnvironmentCustomizer interface represents a customizer for the application environment.
 type EnvironmentCustomizer interface {
 	// CustomizeEnvironment method customizes the given environment for the application.


### PR DESCRIPTION
Remove EnvironmentHolder and ContainerHolder and define their methods directly on the Context interface.