### PR TITLE
fix(component): resolve variadic constructor args correctly

### DIFF
--- a/component/constructor.go
+++ b/component/constructor.go
@@ -92,11 +92,27 @@ func (f Constructor) Invoke(args ...any) (result any, err error) {
 				inputs = append(inputs, reflect.New(variadicType).Elem())
 				continue
 			}
+
+			argVal := reflect.ValueOf(arg)
+
+			if argType.Kind() == reflect.Slice {
+
+				if !argType.Elem().ConvertibleTo(variadicType) {
+					return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, variadicType)
+				}
+
+				for i := 0; i < argVal.Len(); i++ {
+					inputs = append(inputs, argVal.Index(i))
+				}
+
+				continue
+			}
+
 			if !argType.ConvertibleTo(variadicType) {
 				return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, variadicType)
 			}
 
-			inputs = append(inputs, reflect.ValueOf(arg))
+			inputs = append(inputs, argVal)
 			continue
 		}
 
@@ -106,6 +122,7 @@ func (f Constructor) Invoke(args ...any) (result any, err error) {
 			inputs = append(inputs, reflect.New(expectedArgType).Elem())
 			continue
 		}
+
 		if !argType.ConvertibleTo(expectedArgType) {
 			return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, expectedArgType)
 		}

--- a/component/constructor.go
+++ b/component/constructor.go
@@ -92,27 +92,11 @@ func (f Constructor) Invoke(args ...any) (result any, err error) {
 				inputs = append(inputs, reflect.New(variadicType).Elem())
 				continue
 			}
-
-			argVal := reflect.ValueOf(arg)
-
-			if argType.Kind() == reflect.Slice {
-
-				if !argType.Elem().ConvertibleTo(variadicType) {
-					return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, variadicType)
-				}
-
-				for i := 0; i < argVal.Len(); i++ {
-					inputs = append(inputs, argVal.Index(i))
-				}
-
-				continue
-			}
-
 			if !argType.ConvertibleTo(variadicType) {
 				return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, variadicType)
 			}
 
-			inputs = append(inputs, argVal)
+			inputs = append(inputs, reflect.ValueOf(arg))
 			continue
 		}
 
@@ -122,7 +106,6 @@ func (f Constructor) Invoke(args ...any) (result any, err error) {
 			inputs = append(inputs, reflect.New(expectedArgType).Elem())
 			continue
 		}
-
 		if !argType.ConvertibleTo(expectedArgType) {
 			return nil, fmt.Errorf("argument %d has type %v, want %v", index, argType, expectedArgType)
 		}
@@ -142,9 +125,10 @@ func (f Constructor) Invoke(args ...any) (result any, err error) {
 
 // Arg represents an argument of a constructor function.
 type Arg struct {
-	index int          // The index of the argument in the function parameter list.
-	name  string       // The name of the argument.
-	typ   reflect.Type // The type of the argument.
+	index    int          // The index of the argument in the function parameter list.
+	name     string       // The name of the argument.
+	typ      reflect.Type // The type of the argument.
+	variadic bool         // Indicates if the argument is variadic.
 }
 
 // Index returns the index of the argument in the function parameter list.
@@ -162,6 +146,11 @@ func (a Arg) Type() reflect.Type {
 	return a.typ
 }
 
+// IsVariadic returns true if the argument is variadic.
+func (a Arg) IsVariadic() bool {
+	return a.variadic
+}
+
 // extractConstructorArgs returns the list of argument metadata for a given function type.
 func extractConstructorArgs(fnType reflect.Type) []Arg {
 	numIn := fnType.NumIn()
@@ -169,8 +158,9 @@ func extractConstructorArgs(fnType reflect.Type) []Arg {
 
 	for index := 0; index < numIn; index++ {
 		args = append(args, Arg{
-			index: index,
-			typ:   fnType.In(index),
+			index:    index,
+			typ:      fnType.In(index),
+			variadic: fnType.IsVariadic() && index == numIn-1,
 		})
 	}
 

--- a/component/constructor_test.go
+++ b/component/constructor_test.go
@@ -58,6 +58,7 @@ func TestCreateConstructor(t *testing.T) {
 					0,
 					"",
 					reflect.TypeFor[AnySimpleComponent](),
+					false,
 				},
 			},
 		},
@@ -162,44 +163,13 @@ func TestConstructor_Invoke(t *testing.T) {
 			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
 		},
 		{
-			name: "valid variadic constructor with slice argument",
-			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
-				return &AnyDependentComponent{}
-			},
-			inputs: []any{
-				[]AnySimpleComponent{{}, {}},
-			},
-			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
-		},
-		{
-			name: "valid variadic constructor with expanded arguments",
+			name: "valid variadic constructor",
 			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
 				return &AnyDependentComponent{}
 			},
 			inputs: []any{
 				AnySimpleComponent{},
 				AnySimpleComponent{},
-			},
-			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
-		},
-		{
-
-			name: "valid variadic constructor with single argument",
-			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
-				return &AnyDependentComponent{}
-			},
-			inputs: []any{
-				AnySimpleComponent{},
-			},
-			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
-		},
-		{
-			name: "valid constructor with slice parameter",
-			constructorFn: func(dependencies []AnySimpleComponent) *AnyDependentComponent {
-				return &AnyDependentComponent{}
-			},
-			inputs: []any{
-				[]AnySimpleComponent{{}, {}},
 			},
 			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
 		},

--- a/component/constructor_test.go
+++ b/component/constructor_test.go
@@ -162,13 +162,44 @@ func TestConstructor_Invoke(t *testing.T) {
 			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
 		},
 		{
-			name: "valid variadic constructor",
+			name: "valid variadic constructor with slice argument",
+			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
+				return &AnyDependentComponent{}
+			},
+			inputs: []any{
+				[]AnySimpleComponent{{}, {}},
+			},
+			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
+		},
+		{
+			name: "valid variadic constructor with expanded arguments",
 			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
 				return &AnyDependentComponent{}
 			},
 			inputs: []any{
 				AnySimpleComponent{},
 				AnySimpleComponent{},
+			},
+			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
+		},
+		{
+
+			name: "valid variadic constructor with single argument",
+			constructorFn: func(dependencies ...AnySimpleComponent) *AnyDependentComponent {
+				return &AnyDependentComponent{}
+			},
+			inputs: []any{
+				AnySimpleComponent{},
+			},
+			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
+		},
+		{
+			name: "valid constructor with slice parameter",
+			constructorFn: func(dependencies []AnySimpleComponent) *AnyDependentComponent {
+				return &AnyDependentComponent{}
+			},
+			inputs: []any{
+				[]AnySimpleComponent{{}, {}},
 			},
 			wantOutType: reflect.TypeFor[*AnyDependentComponent](),
 		},

--- a/component/container.go
+++ b/component/container.go
@@ -781,12 +781,25 @@ func (d *StandardContainer) resolveArguments(ctx context.Context, args []Arg) ([
 	resolvedArgs := make([]any, 0, len(args))
 
 	for idx, arg := range args {
+		argType := arg.Type()
 
-		if arg.Type().Kind() == reflect.Slice {
-			elemType := arg.Type().Elem()
+		if arg.IsVariadic() {
+			elemType := argType.Elem()
+			instances, err := d.ResolveAll(ctx, elemType)
+
+			if err != nil {
+				return nil, fmt.Errorf("unsatisfied dependency for argument %d (%s): %w", idx, argType, err)
+			}
+
+			resolvedArgs = append(resolvedArgs, instances...)
+			continue
+		}
+
+		if argType.Kind() == reflect.Slice {
+			elemType := argType.Elem()
 			instances, err := d.ResolveAll(ctx, elemType)
 			if err != nil {
-				return nil, fmt.Errorf("unsatisfied dependency for argument %d (%s): %w", idx, arg.Type(), err)
+				return nil, fmt.Errorf("unsatisfied dependency for argument %d (%s): %w", idx, argType, err)
 			}
 
 			sliceVal := reflect.MakeSlice(arg.Type(), len(instances), len(instances))


### PR DESCRIPTION
### Summary

Fixes dependency resolution for constructors with variadic parameters.

Variadic constructor arguments are now identified separately from regular slice arguments. Resolved dependencies are passed as individual arguments, while regular slice parameters continue to receive a single slice value.

### Changes

* Track variadic metadata for constructor arguments
* Resolve variadic dependencies by their element type
* Pass resolved variadic dependencies as individual arguments
* Preserve existing behavior for regular slice parameters

Fixes #41