### PR TITLE
feat(component): add component metadata support

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -31,6 +31,9 @@ var (
 	muComponents = sync.RWMutex{}
 )
 
+// Metadata contains arbitrary key-value pairs associated with a component definition.
+type Metadata map[any]any
+
 // Component represents a registered component and holds its definition.
 type Component struct {
 	definition *Definition

--- a/component/definition.go
+++ b/component/definition.go
@@ -15,7 +15,9 @@
 package component
 
 import (
+	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 )
 
@@ -57,6 +59,7 @@ type Definition struct {
 	name        string
 	scope       string
 	constructor Constructor
+	metadata    Metadata
 }
 
 // Name returns the name of the definition.
@@ -89,6 +92,11 @@ func (d *Definition) Constructor() Constructor {
 	return d.constructor
 }
 
+// Metadata returns a copy of the metadata associated with the component definition
+func (d *Definition) Metadata() Metadata {
+	return maps.Clone(d.metadata)
+}
+
 // MakeDefinition creates a new definition with the provided constructor function and options.
 func MakeDefinition(fn ConstructorFunc, opts ...DefinitionOption) (*Definition, error) {
 	constructor, err := createConstructor(fn)
@@ -110,6 +118,7 @@ func MakeDefinition(fn ConstructorFunc, opts ...DefinitionOption) (*Definition, 
 		name:        componentName,
 		scope:       SingletonScope,
 		constructor: constructor,
+		metadata:    make(Metadata),
 	}
 
 	err = applyDefinitionOpts(def, opts)
@@ -197,6 +206,23 @@ func WithQualifierFor[T any](name string) DefinitionOption {
 			return fmt.Errorf("constructor has no parameter of type %v", typ)
 		}
 
+		return nil
+	}
+}
+
+// WithMetadata adds a metadata key-value pair to the component definition.
+func WithMetadata(key, value any) DefinitionOption {
+	return func(def *Definition) error {
+		if key == nil {
+			return errors.New("nil metadata key")
+
+		}
+
+		if !reflect.TypeOf(key).Comparable() {
+			return fmt.Errorf("metadata key type %T not comparable", key)
+		}
+
+		def.metadata[key] = value
 		return nil
 	}
 }

--- a/component/definition_test.go
+++ b/component/definition_test.go
@@ -34,6 +34,7 @@ func TestMakeDefinition(t *testing.T) {
 		wantType     reflect.Type
 		wantErr      error
 		wantArgNames []string
+		wantMetadata Metadata
 	}{
 		{
 			name:          "nil constructor",
@@ -118,6 +119,38 @@ func TestMakeDefinition(t *testing.T) {
 			wantType:  reflect.TypeFor[*AnyDependentComponent](),
 			wantErr:   errors.New("constructor has no parameter of type string"),
 		},
+		{
+
+			name:          "with metadata",
+			constructorFn: NewAnyPointerComponent,
+			opts: []DefinitionOption{
+				WithMetadata("anyKey", "anyValue"),
+			},
+			wantName:  "anyPointerComponent",
+			wantScope: SingletonScope,
+			wantType:  reflect.TypeFor[*AnyPointerComponent](),
+			wantMetadata: Metadata{
+				"anyKey": "anyValue",
+			},
+		},
+		{
+
+			name:          "with nil metadata key",
+			constructorFn: NewAnyPointerComponent,
+			opts: []DefinitionOption{
+				WithMetadata(nil, "anyValue"),
+			},
+			wantErr: errors.New("metadata key cannot be nil"),
+		},
+		{
+
+			name:          "with non-comparable metadata key",
+			constructorFn: NewAnyPointerComponent,
+			opts: []DefinitionOption{
+				WithMetadata([]string{"anyKey"}, "anyValue"),
+			},
+			wantErr: errors.New("metadata key type []string not comparable"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -161,6 +194,8 @@ func TestMakeDefinition(t *testing.T) {
 				assert.Equal(t, index, args[index].Index())
 				assert.Equal(t, wantArg, args[index].Name())
 			}
+
+			assert.Equal(t, tc.wantMetadata, def.Metadata())
 		})
 	}
 }


### PR DESCRIPTION
**Summary**

Adds metadata support to component definitions.

Metadata can be attached when creating or registering components using the WithMetadata definition option and accessed through the component definition.

```go
component.Register(
    newComponent,
    component.WithMetadata("anyKey", "anyValue"),
)
```

Changes

* Add the Metadata type for storing component metadata
* Add the WithMetadata definition option
* Expose metadata through component definitions
* Validate metadata keys
* Add test coverage for component metadata

Closes #49