### PR TITLE
fix(config): bind embedded property structs

### DIFF
--- a/runtime/config/binder.go
+++ b/runtime/config/binder.go
@@ -206,6 +206,14 @@ func (b *DefaultPropertyBinder) bindStruct(name string, targetVal reflect.Value)
 		propTag := &PropertyTag{}
 		tags := string(field.Tag)
 		if len(tags) == 0 {
+			if field.Anonymous && fieldVal.Kind() == reflect.Struct {
+				err := b.bindStruct(name, fieldVal)
+				if err != nil {
+					return fmt.Errorf("embedded struct field %q: %w", field.Name, err)
+				}
+
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
### Summary

Adds support for binding fields from embedded property structs without requiring a property tag on the embedded field.

Embedded fields are now bound using the parent property prefix, allowing common configuration properties to be reused across different property types.

### Changes

* Detect untagged embedded struct fields during property binding
* Bind embedded struct fields using the parent property prefix
* Preserve existing behavior for tagged struct fields

Fixes #52